### PR TITLE
Build nvim as release version to improve performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ADD nvim-appimage-appimagetool.patch nvim-appimage-appimagetool.patch
 
 RUN \
   patch -p1 <nvim-appimage-appimagetool.patch && \
-  make appimage
+  make CMAKE_BUILD_TYPE=Release appimage
 
 FROM busybox
 


### PR DESCRIPTION
IMO, this repository is intended for Neovim users, not Neovim developers.
Therefore, please build it as a release version to improve performance.

### Binary from current version
```
% vi --version
NVIM v0.10.2
Build type: Debug
LuaJIT 2.1.1713484068
Run "nvim -V1 -v" for more info
```

### Binary from patched version
```
% vi --version
NVIM v0.10.2
Build type: Release
LuaJIT 2.1.1713484068
Run "nvim -V1 -v" for more info
```