### PR TITLE
Fix build type from Debug -> Release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@ FROM ubuntu:20.04 as build
 
 ARG BRANCH=master
 ENV DEBIAN_FRONTEND=noninteractive
+ENV CMAKE_BUILD_TYPE=Release
 
 RUN \
   apt update && \
   apt upgrade -y && \
-  apt install -y automake cmake curl g++ gettext git libtool-bin make pkg-config unzip && \
-  git clone -b ${BRANCH} --single-branch --depth 1 https://github.com/neovim/neovim.git
+  apt install -y automake cmake curl g++ gettext git libtool-bin make pkg-config unzip
+
+RUN  git clone -b ${BRANCH} --single-branch --depth 1 https://github.com/neovim/neovim.git
 
 WORKDIR neovim
 


### PR DESCRIPTION
Thanks for creating this repo, saved me a lot of time when using NVIM on my raspberry.

Recently I had some storage issue where the VIM logs was taking like 37GB, I discover that this is due to some flags when compiling NVIM (https://www.reddit.com/r/neovim/comments/13hsj74/neovim_log_weights_17gb_is_it_normal/) where the Debug release type would print a crazy amount of logs.

This PR fix the issue by using the Release build type, which I think should be preferrable in all use cases for this repo